### PR TITLE
put yen signs below chef name and remove the non-styled “Japanese off…

### DIFF
--- a/app/views/offers/index.html.erb
+++ b/app/views/offers/index.html.erb
@@ -11,8 +11,10 @@
       <div class="col-3 my-3">
         <div class="card">
           <div class="card-category" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url(https://images.unsplash.com/photo-1467003909585-2f8a72700288?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTJ8fGZvb2R8ZW58MHx8MHx8fDA%3D&auto=format&fit=crop&w=500&q=60)">
-            <h2 class="text-center text-light"><%= chef %></h2>
-            <p class="text-center text-dark">¥<%= price.sample %></p>
+            <div class="text-center">
+              <h2 class="text-center text-light"><%= chef %></h2>
+              <p class="text-center text-dark">¥<%= price.sample %></p>
+            </div>
           </div>
           <%= link_to "Find out more", "/offers/1", class: "btn btn-primary" %>
         </div>

--- a/app/views/offers/show.html.erb
+++ b/app/views/offers/show.html.erb
@@ -1,5 +1,3 @@
-<h1><%= @offer.cuisine %> Offer Details</h1>
-
 <div class="container">
   <div class="row my-3">
     <div class="col-12 my-3">


### PR DESCRIPTION
I put the yen sign below the chef name and remove the non-styled “Japanese offer details” in the show page.
<img width="1439" alt="Screenshot 2023-07-22 at 15 46 49" src="https://github.com/Buruburu1101/chef_on_demand/assets/127472894/f00486f7-2750-4030-886e-bf6289cd28fd">
<img width="1430" alt="Screenshot 2023-07-22 at 15 47 22" src="https://github.com/Buruburu1101/chef_on_demand/assets/127472894/2dea9da3-79d7-469a-94c8-b7c63118aeb5">
